### PR TITLE
Update event handling to work in 11.0

### DIFF
--- a/HideCraftingChat.lua
+++ b/HideCraftingChat.lua
@@ -1,6 +1,6 @@
 local filterFunc = function(self, event, msg, author, ...)
-    if msg:find("creates:") then
+    if msg:find("creates") then
         return true
     end
 end
-ChatFrame_AddMessageEventFilter("CHAT_MSG_LOOT", filterFunc)
+ChatFrame_AddMessageEventFilter("CHAT_MSG_TRADESKILLS", filterFunc)


### PR DESCRIPTION
Trade skills are now on a TRADESKILLS event and there's no colon (":") in the message.