### PR TITLE
Use the player's name to determine msg should be hidden

### DIFF
--- a/HideCraftingChat.lua
+++ b/HideCraftingChat.lua
@@ -1,5 +1,5 @@
 local filterFunc = function(self, event, msg, author, ...)
-    if msg:find("creates") then
+    if author ~= UnitName("player") then
         return true
     end
 end


### PR DESCRIPTION
Instead of scanning the msg for "creates" which could result in hiding false positives, instead hide any message on the TRADESKILLS channel whose author is not the player.